### PR TITLE
port fixed

### DIFF
--- a/demo/src/androidMain/kotlin/com/seanproctor/onvifdemo/MainActivity.kt
+++ b/demo/src/androidMain/kotlin/com/seanproctor/onvifdemo/MainActivity.kt
@@ -20,11 +20,8 @@ class MainActivity : ComponentActivity() {
 
         Napier.base(DebugAntilog())
         val logger = object : OnvifLogger {
-            override fun error(message: String) {
-                Napier.e(message)
-            }
 
-            override fun error(message: String, e: Throwable) {
+            override fun error(message: String, e: Throwable?) {
                 Napier.e(message, e)
             }
 

--- a/onvifcamera/src/commonMain/kotlin/com/seanproctor/onvifcamera/OnvifDevice.kt
+++ b/onvifcamera/src/commonMain/kotlin/com/seanproctor/onvifcamera/OnvifDevice.kt
@@ -65,6 +65,7 @@ public class OnvifDevice internal constructor(
         return URLBuilder().apply {
             protocol = address.protocol
             host = address.host
+            port = address.port
             encodedPath = path
         }
             .buildString()


### PR DESCRIPTION
When connecting to device, connection refused error is throwing because port is not assigned in build url method.