### PR TITLE
Use version catalog for compose.material3 in androidDemo

### DIFF
--- a/androidDemo/build.gradle.kts
+++ b/androidDemo/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.compose)
@@ -17,7 +15,7 @@ kotlin {
         implementation(libs.ktor.client.logging)
 
         // Compose dependencies
-        implementation(compose.material3)
+        implementation(libs.compose.material3)
         implementation(libs.material.icons)
 
         implementation(libs.lifecycle.viewmodel.compose)


### PR DESCRIPTION
## Summary
Completes the `compose.material3` → `libs.compose.material3` migration on the `androidDemo` module. The sibling `demo` module was already migrated; this drops the deprecated Compose DSL accessor on `androidDemo` too and removes a now-unused import.

## Test plan
- `./gradlew :androidDemo:build` resolves `libs.compose.material3` and compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)