### PR TITLE
Bump version to 2.2.1

### DIFF
--- a/onvifcamera/build.gradle.kts
+++ b/onvifcamera/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.seanproctor"
-version = "2.2.0"
+version = "2.2.1"
 
 kotlin {
     androidLibrary {


### PR DESCRIPTION
## Summary
Bumps the `:onvifcamera` library version from 2.2.0 to 2.2.1.

This patch release covers the changes merged since 2.2.0:
- **Fix:** SOAP request values (profile tokens, protocol, discovery message id) are now XML-escaped, so special characters no longer produce malformed requests (#11).
- **Internal:** ONVIF SOAP requests are now built with kotlinx-serialization rather than hand-concatenated XML (no public API change) (#11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)